### PR TITLE
Update vi command reference in troubleshooting guide

### DIFF
--- a/instructions/azure-kubernetes-service/03-aks-troubleshoot-container.md
+++ b/instructions/azure-kubernetes-service/03-aks-troubleshoot-container.md
@@ -173,7 +173,7 @@ A Service routes traffic to pods based on label selectors. When labels don't mat
 1. In the editor, find the **selector** section and change **app: api-v2** to `app: api`. Save the changes and exit the editor by selecting **Esc**, typing **:wq**, and then selecting **Enter**.
 
     >**Note:** The editor uses vi commands. Quick reference:
-    >
+    > &nbsp;
     >| Action | Command |
     >|--------|---------|
     >| Navigate | Arrow keys (**↑ ↓ ← →**) |


### PR DESCRIPTION
Added a note about the vi command for exiting the editor.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-