### PR TITLE
Moved cosmosdb container creation to deployment script

### DIFF
--- a/finished/cosmosdb/implement-vector/python/azdeploy.ps1
+++ b/finished/cosmosdb/implement-vector/python/azdeploy.ps1
@@ -91,7 +91,72 @@ function Create-CosmosDBAccount {
     }
 
     Write-Host ""
-    Write-Host "Use option 2 to configure Entra ID access."
+    Write-Host "Use option 2 to create the container."
+}
+
+# Function to create container with vector embedding and indexing policies
+function Create-Containers {
+    Write-Host "Creating container with vector search policies..."
+
+    # Prereq check: Cosmos DB account must exist and be ready
+    $status = (az cosmosdb show --resource-group $rg --name $accountName --query "provisioningState" -o tsv 2>$null)
+    if ([string]::IsNullOrWhiteSpace($status)) {
+        Write-Host "Error: Cosmos DB account '$accountName' not found."
+        Write-Host "Please run option 1 to create the Cosmos DB account, then try again."
+        return
+    }
+
+    if ($status -ne "Succeeded") {
+        Write-Host "Error: Cosmos DB account is not ready (current state: $status)."
+        Write-Host "Please wait for deployment to complete. Use option 4 to check status."
+        return
+    }
+
+    # Check if container already exists
+    az cosmosdb sql container show `
+        --resource-group $rg `
+        --account-name $accountName `
+        --database-name $databaseName `
+        --name $containerName 2>$null | Out-Null
+
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "$([char]0x2713) Container already exists: $containerName"
+        return
+    }
+
+    # Create container with vector embedding policy and indexing policy (DiskANN)
+    $indexingPolicy = '{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/embedding/*"}],"vectorIndexes":[{"path":"/embedding","type":"diskANN"}]}'
+    $vectorPolicy = '{"vectorEmbeddings":[{"path":"/embedding","dataType":"float32","distanceFunction":"cosine","dimensions":256}]}'
+
+    az cosmosdb sql container create `
+        --resource-group $rg `
+        --account-name $accountName `
+        --database-name $databaseName `
+        --name $containerName `
+        --partition-key-path "/documentId" `
+        --idx $indexingPolicy `
+        --vector-embeddings $vectorPolicy 2>$null | Out-Null
+
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "$([char]0x2713) Container created: $containerName"
+        Write-Host ""
+        Write-Host "  Vector embedding policy:"
+        Write-Host "    - Path: /embedding"
+        Write-Host "    - Data type: float32"
+        Write-Host "    - Distance function: cosine"
+        Write-Host "    - Dimensions: 256"
+        Write-Host ""
+        Write-Host "  Indexing policy:"
+        Write-Host "    - Vector index type: diskANN"
+        Write-Host "    - Embedding path excluded from standard indexing"
+    }
+    else {
+        Write-Host "Error: Failed to create container"
+        return
+    }
+
+    Write-Host ""
+    Write-Host "Use option 3 to configure Entra ID access."
 }
 
 # Function to configure Entra ID RBAC for the signed-in user
@@ -108,7 +173,7 @@ function Configure-EntraAccess {
 
     if ($status -ne "Succeeded") {
         Write-Host "Error: Cosmos DB account is not ready (current state: $status)."
-        Write-Host "Please wait for deployment to complete. Use option 3 to check status."
+        Write-Host "Please wait for deployment to complete. Use option 4 to check status."
         return
     }
 
@@ -223,6 +288,15 @@ function Check-DeploymentStatus {
                 Write-Host "  $([char]0x26A0) Database not created"
             }
 
+            # Check container
+            az cosmosdb sql container show --resource-group $rg --account-name $accountName --database-name $databaseName --name $containerName 2>$null | Out-Null
+            if ($LASTEXITCODE -eq 0) {
+                Write-Host "  $([char]0x2713) Container: $containerName"
+            }
+            else {
+                Write-Host "  $([char]0x26A0) Container not created"
+            }
+
             # Check Entra ID RBAC
             $userUpn = (az ad signed-in-user show --query userPrincipalName -o tsv 2>$null)
             $accountId = (az cosmosdb show --resource-group $rg --name $accountName --query "id" -o tsv)
@@ -279,7 +353,7 @@ function Retrieve-ConnectionInfo {
 
     if ([string]::IsNullOrWhiteSpace($cosmosRole)) {
         Write-Host "Error: Entra ID access not configured for this account."
-        Write-Host "Please run option 2 to configure Entra ID access, then try again."
+        Write-Host "Please run option 3 to configure Entra ID access, then try again."
         return
     }
 
@@ -323,17 +397,18 @@ function Show-Menu {
     Write-Host "Location: $location"
     Write-Host "====================================================================="
     Write-Host "1. Create Cosmos DB account (with vector search capability)"
-    Write-Host "2. Configure Entra ID access"
-    Write-Host "3. Check deployment status"
-    Write-Host "4. Retrieve connection info"
-    Write-Host "5. Exit"
+    Write-Host "2. Create container (with vector indexing policies)"
+    Write-Host "3. Configure Entra ID access"
+    Write-Host "4. Check deployment status"
+    Write-Host "5. Retrieve connection info"
+    Write-Host "6. Exit"
     Write-Host "====================================================================="
 }
 
 # Main menu loop
 while ($true) {
     Show-Menu
-    $choice = Read-Host "Please select an option (1-5)"
+    $choice = Read-Host "Please select an option (1-6)"
 
     switch ($choice) {
         "1" {
@@ -346,30 +421,36 @@ while ($true) {
         }
         "2" {
             Write-Host ""
-            Configure-EntraAccess
+            Create-Containers
             Write-Host ""
             Read-Host "Press Enter to continue..."
         }
         "3" {
             Write-Host ""
-            Check-DeploymentStatus
+            Configure-EntraAccess
             Write-Host ""
             Read-Host "Press Enter to continue..."
         }
         "4" {
             Write-Host ""
-            Retrieve-ConnectionInfo
+            Check-DeploymentStatus
             Write-Host ""
             Read-Host "Press Enter to continue..."
         }
         "5" {
+            Write-Host ""
+            Retrieve-ConnectionInfo
+            Write-Host ""
+            Read-Host "Press Enter to continue..."
+        }
+        "6" {
             Write-Host "Exiting..."
             Clear-Host
             exit 0
         }
         default {
             Write-Host ""
-            Write-Host "Invalid option. Please select 1-5."
+            Write-Host "Invalid option. Please select 1-6."
             Write-Host ""
             Read-Host "Press Enter to continue..."
         }

--- a/finished/cosmosdb/implement-vector/python/azdeploy.sh
+++ b/finished/cosmosdb/implement-vector/python/azdeploy.sh
@@ -83,7 +83,68 @@ create_cosmosdb_account() {
     fi
 
     echo ""
-    echo "Use option 2 to configure Entra ID access."
+    echo "Use option 2 to create the container."
+}
+
+# Function to create container with vector embedding and indexing policies
+create_containers() {
+    echo "Creating container with vector search policies..."
+
+    # Prereq check: Cosmos DB account must exist and be ready
+    local status=$(az cosmosdb show --resource-group $rg --name $account_name --query "provisioningState" -o tsv 2>/dev/null)
+    if [ -z "$status" ]; then
+        echo "Error: Cosmos DB account '$account_name' not found."
+        echo "Please run option 1 to create the Cosmos DB account, then try again."
+        return 1
+    fi
+
+    if [ "$status" != "Succeeded" ]; then
+        echo "Error: Cosmos DB account is not ready (current state: $status)."
+        echo "Please wait for deployment to complete. Use option 4 to check status."
+        return 1
+    fi
+
+    # Check if container already exists
+    local container_exists=$(az cosmosdb sql container show \
+        --resource-group $rg \
+        --account-name $account_name \
+        --database-name $database_name \
+        --name $container_name 2>/dev/null)
+
+    if [ -n "$container_exists" ]; then
+        echo "✓ Container already exists: $container_name"
+        return 0
+    fi
+
+    # Create container with vector embedding policy and indexing policy (DiskANN)
+    az cosmosdb sql container create \
+        --resource-group $rg \
+        --account-name $account_name \
+        --database-name $database_name \
+        --name $container_name \
+        --partition-key-path "/documentId" \
+        --idx '{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/embedding/*"}],"vectorIndexes":[{"path":"/embedding","type":"diskANN"}]}' \
+        --vector-embeddings '{"vectorEmbeddings":[{"path":"/embedding","dataType":"float32","distanceFunction":"cosine","dimensions":256}]}' > /dev/null 2>&1
+
+    if [ $? -eq 0 ]; then
+        echo "✓ Container created: $container_name"
+        echo ""
+        echo "  Vector embedding policy:"
+        echo "    - Path: /embedding"
+        echo "    - Data type: float32"
+        echo "    - Distance function: cosine"
+        echo "    - Dimensions: 256"
+        echo ""
+        echo "  Indexing policy:"
+        echo "    - Vector index type: diskANN"
+        echo "    - Embedding path excluded from standard indexing"
+    else
+        echo "Error: Failed to create container"
+        return 1
+    fi
+
+    echo ""
+    echo "Use option 3 to configure Entra ID access."
 }
 
 # Function to configure Entra ID RBAC for the signed-in user
@@ -198,7 +259,7 @@ retrieve_connection_info() {
 
     if [ -z "$cosmos_role" ]; then
         echo "Error: Entra ID access not configured for this account."
-        echo "Please run option 2 to configure Entra ID access, then try again."
+        echo "Please run option 3 to configure Entra ID access, then try again."
         return 1
     fi
 
@@ -262,6 +323,14 @@ check_deployment_status() {
                 echo "  ⚠ Database not created"
             fi
 
+            # Check container
+            local container_status=$(az cosmosdb sql container show --resource-group $rg --account-name $account_name --database-name $database_name --name $container_name 2>/dev/null)
+            if [ -n "$container_status" ]; then
+                echo "  ✓ Container: $container_name"
+            else
+                echo "  ⚠ Container not created"
+            fi
+
             # Check Entra ID RBAC
             local user_upn=$(az ad signed-in-user show --query userPrincipalName -o tsv 2>/dev/null)
             local account_id=$(az cosmosdb show --resource-group $rg --name $account_name --query "id" -o tsv)
@@ -304,17 +373,18 @@ show_menu() {
     echo "Location: $location"
     echo "====================================================================="
     echo "1. Create Cosmos DB account (with vector search capability)"
-    echo "2. Configure Entra ID access"
-    echo "3. Check deployment status"
-    echo "4. Retrieve connection info"
-    echo "5. Exit"
+    echo "2. Create container (with vector indexing policies)"
+    echo "3. Configure Entra ID access"
+    echo "4. Check deployment status"
+    echo "5. Retrieve connection info"
+    echo "6. Exit"
     echo "====================================================================="
 }
 
 # Main menu loop
 while true; do
     show_menu
-    read -p "Please select an option (1-5): " choice
+    read -p "Please select an option (1-6): " choice
 
     case $choice in
         1)
@@ -327,30 +397,36 @@ while true; do
             ;;
         2)
             echo ""
-            configure_entra_access
+            create_containers
             echo ""
             read -p "Press Enter to continue..."
             ;;
         3)
             echo ""
-            check_deployment_status
+            configure_entra_access
             echo ""
             read -p "Press Enter to continue..."
             ;;
         4)
             echo ""
-            retrieve_connection_info
+            check_deployment_status
             echo ""
             read -p "Press Enter to continue..."
             ;;
         5)
+            echo ""
+            retrieve_connection_info
+            echo ""
+            read -p "Press Enter to continue..."
+            ;;
+        6)
             echo "Exiting..."
             clear
             exit 0
             ;;
         *)
             echo ""
-            echo "Invalid option. Please select 1-5."
+            echo "Invalid option. Please select 1-6."
             echo ""
             read -p "Press Enter to continue..."
             ;;

--- a/finished/cosmosdb/optimize-query/python/azdeploy.ps1
+++ b/finished/cosmosdb/optimize-query/python/azdeploy.ps1
@@ -90,7 +90,80 @@ function Create-CosmosDBAccount {
     }
 
     Write-Host ""
-    Write-Host "Use option 2 to configure Entra ID access."
+    Write-Host "Use option 2 to create the containers."
+}
+
+# Function to create containers with different vector indexing strategies
+function Create-Containers {
+    Write-Host "Creating containers with vector indexing policies..."
+
+    # Prereq check: Cosmos DB account must exist and be ready
+    $status = (az cosmosdb show --resource-group $rg --name $accountName --query "provisioningState" -o tsv 2>$null)
+    if ([string]::IsNullOrWhiteSpace($status)) {
+        Write-Host "Error: Cosmos DB account '$accountName' not found."
+        Write-Host "Please run option 1 to create the Cosmos DB account, then try again."
+        return
+    }
+
+    if ($status -ne "Succeeded") {
+        Write-Host "Error: Cosmos DB account is not ready (current state: $status)."
+        Write-Host "Please wait for deployment to complete. Use option 4 to check status."
+        return
+    }
+
+    $vectorPolicy = '{"vectorEmbeddings":[{"path":"/embedding","dataType":"float32","distanceFunction":"cosine","dimensions":256}]}'
+    $created = 0
+
+    # Define containers: name and index type
+    $containers = @(
+        @{ Name = "vectors-flat"; Type = "flat"; Description = "exact nearest neighbor" },
+        @{ Name = "vectors-quantized"; Type = "quantizedFlat"; Description = "compressed exact search" },
+        @{ Name = "vectors-diskann"; Type = "diskANN"; Description = "approximate nearest neighbor" }
+    )
+
+    foreach ($container in $containers) {
+        az cosmosdb sql container show --resource-group $rg --account-name $accountName --database-name $databaseName --name $container.Name 2>$null | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "$([char]0x2713) Container already exists: $($container.Name)"
+        }
+        else {
+            Write-Host "Creating container '$($container.Name)' with $($container.Type) vector index..."
+            $indexingPolicy = '{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/embedding/*"}],"vectorIndexes":[{"path":"/embedding","type":"' + $container.Type + '"}]}'
+
+            az cosmosdb sql container create `
+                --resource-group $rg `
+                --account-name $accountName `
+                --database-name $databaseName `
+                --name $container.Name `
+                --partition-key-path "/documentId" `
+                --idx $indexingPolicy `
+                --vector-embeddings $vectorPolicy 2>$null | Out-Null
+
+            if ($LASTEXITCODE -eq 0) {
+                Write-Host "$([char]0x2713) Container created: $($container.Name) ($($container.Description))"
+                $created++
+            }
+            else {
+                Write-Host "Error: Failed to create container $($container.Name)"
+                return
+            }
+        }
+    }
+
+    if ($created -gt 0) {
+        Write-Host ""
+        Write-Host "All containers share:"
+        Write-Host "  - Partition key: /documentId"
+        Write-Host "  - Vector embedding: /embedding (float32, cosine, 256 dimensions)"
+        Write-Host ""
+        Write-Host "Index types:"
+        Write-Host "  - vectors-flat: flat (exact search)"
+        Write-Host "  - vectors-quantized: quantizedFlat (compressed exact search)"
+        Write-Host "  - vectors-diskann: diskANN (approximate nearest neighbor)"
+    }
+
+    Write-Host ""
+    Write-Host "Use option 3 to configure Entra ID access."
 }
 
 # Function to configure Entra ID RBAC for the signed-in user
@@ -107,7 +180,7 @@ function Configure-EntraAccess {
 
     if ($status -ne "Succeeded") {
         Write-Host "Error: Cosmos DB account is not ready (current state: $status)."
-        Write-Host "Please wait for deployment to complete. Use option 3 to check status."
+        Write-Host "Please wait for deployment to complete. Use option 4 to check status."
         return
     }
 
@@ -222,6 +295,17 @@ function Check-DeploymentStatus {
                 Write-Host "  $([char]0x26A0) Database not created"
             }
 
+            # Check containers
+            foreach ($cname in @("vectors-flat", "vectors-quantized", "vectors-diskann")) {
+                az cosmosdb sql container show --resource-group $rg --account-name $accountName --database-name $databaseName --name $cname 2>$null | Out-Null
+                if ($LASTEXITCODE -eq 0) {
+                    Write-Host "  $([char]0x2713) Container: $cname"
+                }
+                else {
+                    Write-Host "  $([char]0x26A0) Container not created: $cname"
+                }
+            }
+
             # Check Entra ID RBAC
             $userUpn = (az ad signed-in-user show --query userPrincipalName -o tsv 2>$null)
             $accountId = (az cosmosdb show --resource-group $rg --name $accountName --query "id" -o tsv)
@@ -278,7 +362,7 @@ function Retrieve-ConnectionInfo {
 
     if ([string]::IsNullOrWhiteSpace($cosmosRole)) {
         Write-Host "Error: Entra ID access not configured for this account."
-        Write-Host "Please run option 2 to configure Entra ID access, then try again."
+        Write-Host "Please run option 3 to configure Entra ID access, then try again."
         return
     }
 
@@ -294,7 +378,6 @@ function Retrieve-ConnectionInfo {
     $envFile = Join-Path $scriptDir ".env.ps1"
 
     # Create or update .env.ps1 file with environment variable assignments (no key needed for Entra auth)
-    # Note: Containers are created by setup_containers.py with different index types
     @(
         "`$env:COSMOS_ENDPOINT = `"$endpoint`"",
         "`$env:COSMOS_DATABASE = `"$databaseName`""
@@ -307,7 +390,7 @@ function Retrieve-ConnectionInfo {
     Write-Host "Database: $databaseName"
     Write-Host "Authentication: Microsoft Entra ID (DefaultAzureCredential)"
     Write-Host ""
-    Write-Host "Note: Containers will be created by setup_containers.py"
+    Write-Host "Containers: vectors-flat, vectors-quantized, vectors-diskann"
     Write-Host ""
     Write-Host "Environment variables saved to: $envFile"
 }
@@ -323,17 +406,18 @@ function Show-Menu {
     Write-Host "Location: $location"
     Write-Host "====================================================================="
     Write-Host "1. Create Cosmos DB account (with vector search capability)"
-    Write-Host "2. Configure Entra ID access"
-    Write-Host "3. Check deployment status"
-    Write-Host "4. Retrieve connection info"
-    Write-Host "5. Exit"
+    Write-Host "2. Create containers (with vector indexing policies)"
+    Write-Host "3. Configure Entra ID access"
+    Write-Host "4. Check deployment status"
+    Write-Host "5. Retrieve connection info"
+    Write-Host "6. Exit"
     Write-Host "====================================================================="
 }
 
 # Main menu loop
 while ($true) {
     Show-Menu
-    $choice = Read-Host "Please select an option (1-5)"
+    $choice = Read-Host "Please select an option (1-6)"
 
     switch ($choice) {
         "1" {
@@ -346,30 +430,36 @@ while ($true) {
         }
         "2" {
             Write-Host ""
-            Configure-EntraAccess
+            Create-Containers
             Write-Host ""
             Read-Host "Press Enter to continue..."
         }
         "3" {
             Write-Host ""
-            Check-DeploymentStatus
+            Configure-EntraAccess
             Write-Host ""
             Read-Host "Press Enter to continue..."
         }
         "4" {
             Write-Host ""
-            Retrieve-ConnectionInfo
+            Check-DeploymentStatus
             Write-Host ""
             Read-Host "Press Enter to continue..."
         }
         "5" {
+            Write-Host ""
+            Retrieve-ConnectionInfo
+            Write-Host ""
+            Read-Host "Press Enter to continue..."
+        }
+        "6" {
             Write-Host "Exiting..."
             Clear-Host
             exit 0
         }
         default {
             Write-Host ""
-            Write-Host "Invalid option. Please select 1-5."
+            Write-Host "Invalid option. Please select 1-6."
             Write-Host ""
             Read-Host "Press Enter to continue..."
         }

--- a/finished/cosmosdb/optimize-query/python/azdeploy.sh
+++ b/finished/cosmosdb/optimize-query/python/azdeploy.sh
@@ -82,7 +82,116 @@ create_cosmosdb_account() {
     fi
 
     echo ""
-    echo "Use option 2 to configure Entra ID access."
+    echo "Use option 2 to create the containers."
+}
+
+# Function to create containers with different vector indexing strategies
+create_containers() {
+    echo "Creating containers with vector indexing policies..."
+
+    # Prereq check: Cosmos DB account must exist and be ready
+    local status=$(az cosmosdb show --resource-group $rg --name $account_name --query "provisioningState" -o tsv 2>/dev/null)
+    if [ -z "$status" ]; then
+        echo "Error: Cosmos DB account '$account_name' not found."
+        echo "Please run option 1 to create the Cosmos DB account, then try again."
+        return 1
+    fi
+
+    if [ "$status" != "Succeeded" ]; then
+        echo "Error: Cosmos DB account is not ready (current state: $status)."
+        echo "Please wait for deployment to complete. Use option 4 to check status."
+        return 1
+    fi
+
+    local vector_policy='{"vectorEmbeddings":[{"path":"/embedding","dataType":"float32","distanceFunction":"cosine","dimensions":256}]}'
+    local created=0
+
+    # Create vectors-flat container (exact nearest neighbor search)
+    local exists=$(az cosmosdb sql container show --resource-group $rg --account-name $account_name --database-name $database_name --name "vectors-flat" 2>/dev/null)
+    if [ -n "$exists" ]; then
+        echo "✓ Container already exists: vectors-flat"
+    else
+        echo "Creating container 'vectors-flat' with flat vector index..."
+        az cosmosdb sql container create \
+            --resource-group $rg \
+            --account-name $account_name \
+            --database-name $database_name \
+            --name "vectors-flat" \
+            --partition-key-path "/documentId" \
+            --idx '{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/embedding/*"}],"vectorIndexes":[{"path":"/embedding","type":"flat"}]}' \
+            --vector-embeddings "$vector_policy" > /dev/null 2>&1
+
+        if [ $? -eq 0 ]; then
+            echo "✓ Container created: vectors-flat (exact nearest neighbor)"
+            created=$((created + 1))
+        else
+            echo "Error: Failed to create container vectors-flat"
+            return 1
+        fi
+    fi
+
+    # Create vectors-quantized container (compressed exact search)
+    exists=$(az cosmosdb sql container show --resource-group $rg --account-name $account_name --database-name $database_name --name "vectors-quantized" 2>/dev/null)
+    if [ -n "$exists" ]; then
+        echo "✓ Container already exists: vectors-quantized"
+    else
+        echo "Creating container 'vectors-quantized' with quantizedFlat vector index..."
+        az cosmosdb sql container create \
+            --resource-group $rg \
+            --account-name $account_name \
+            --database-name $database_name \
+            --name "vectors-quantized" \
+            --partition-key-path "/documentId" \
+            --idx '{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/embedding/*"}],"vectorIndexes":[{"path":"/embedding","type":"quantizedFlat"}]}' \
+            --vector-embeddings "$vector_policy" > /dev/null 2>&1
+
+        if [ $? -eq 0 ]; then
+            echo "✓ Container created: vectors-quantized (compressed exact search)"
+            created=$((created + 1))
+        else
+            echo "Error: Failed to create container vectors-quantized"
+            return 1
+        fi
+    fi
+
+    # Create vectors-diskann container (approximate nearest neighbor)
+    exists=$(az cosmosdb sql container show --resource-group $rg --account-name $account_name --database-name $database_name --name "vectors-diskann" 2>/dev/null)
+    if [ -n "$exists" ]; then
+        echo "✓ Container already exists: vectors-diskann"
+    else
+        echo "Creating container 'vectors-diskann' with diskANN vector index..."
+        az cosmosdb sql container create \
+            --resource-group $rg \
+            --account-name $account_name \
+            --database-name $database_name \
+            --name "vectors-diskann" \
+            --partition-key-path "/documentId" \
+            --idx '{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/embedding/*"}],"vectorIndexes":[{"path":"/embedding","type":"diskANN"}]}' \
+            --vector-embeddings "$vector_policy" > /dev/null 2>&1
+
+        if [ $? -eq 0 ]; then
+            echo "✓ Container created: vectors-diskann (approximate nearest neighbor)"
+            created=$((created + 1))
+        else
+            echo "Error: Failed to create container vectors-diskann"
+            return 1
+        fi
+    fi
+
+    if [ $created -gt 0 ]; then
+        echo ""
+        echo "All containers share:"
+        echo "  - Partition key: /documentId"
+        echo "  - Vector embedding: /embedding (float32, cosine, 256 dimensions)"
+        echo ""
+        echo "Index types:"
+        echo "  - vectors-flat: flat (exact search)"
+        echo "  - vectors-quantized: quantizedFlat (compressed exact search)"
+        echo "  - vectors-diskann: diskANN (approximate nearest neighbor)"
+    fi
+
+    echo ""
+    echo "Use option 3 to configure Entra ID access."
 }
 
 # Function to configure Entra ID RBAC for the signed-in user
@@ -197,7 +306,7 @@ retrieve_connection_info() {
 
     if [ -z "$cosmos_role" ]; then
         echo "Error: Entra ID access not configured for this account."
-        echo "Please run option 2 to configure Entra ID access, then try again."
+        echo "Please run option 3 to configure Entra ID access, then try again."
         return 1
     fi
 
@@ -212,7 +321,6 @@ retrieve_connection_info() {
     local env_file="$(dirname "$0")/.env"
 
     # Create or update .env file with export statements (no key needed for Entra auth)
-    # Note: Containers are created by setup_containers.py with different index types
     cat > "$env_file" << EOF
 export COSMOS_ENDPOINT="$endpoint"
 export COSMOS_DATABASE="$database_name"
@@ -225,7 +333,7 @@ EOF
     echo "Database: $database_name"
     echo "Authentication: Microsoft Entra ID (DefaultAzureCredential)"
     echo ""
-    echo "Note: Containers will be created by setup_containers.py"
+    echo "Containers: vectors-flat, vectors-quantized, vectors-diskann"
     echo ""
     echo "Environment variables saved to: $env_file"
 }
@@ -261,6 +369,16 @@ check_deployment_status() {
             else
                 echo "  ⚠ Database not created"
             fi
+
+            # Check containers
+            for cname in "vectors-flat" "vectors-quantized" "vectors-diskann"; do
+                local c_status=$(az cosmosdb sql container show --resource-group $rg --account-name $account_name --database-name $database_name --name $cname 2>/dev/null)
+                if [ -n "$c_status" ]; then
+                    echo "  ✓ Container: $cname"
+                else
+                    echo "  ⚠ Container not created: $cname"
+                fi
+            done
 
             # Check Entra ID RBAC
             local user_upn=$(az ad signed-in-user show --query userPrincipalName -o tsv 2>/dev/null)
@@ -304,17 +422,18 @@ show_menu() {
     echo "Location: $location"
     echo "====================================================================="
     echo "1. Create Cosmos DB account (with vector search capability)"
-    echo "2. Configure Entra ID access"
-    echo "3. Check deployment status"
-    echo "4. Retrieve connection info"
-    echo "5. Exit"
+    echo "2. Create containers (with vector indexing policies)"
+    echo "3. Configure Entra ID access"
+    echo "4. Check deployment status"
+    echo "5. Retrieve connection info"
+    echo "6. Exit"
     echo "====================================================================="
 }
 
 # Main menu loop
 while true; do
     show_menu
-    read -p "Please select an option (1-5): " choice
+    read -p "Please select an option (1-6): " choice
 
     case $choice in
         1)
@@ -327,30 +446,36 @@ while true; do
             ;;
         2)
             echo ""
-            configure_entra_access
+            create_containers
             echo ""
             read -p "Press Enter to continue..."
             ;;
         3)
             echo ""
-            check_deployment_status
+            configure_entra_access
             echo ""
             read -p "Press Enter to continue..."
             ;;
         4)
             echo ""
-            retrieve_connection_info
+            check_deployment_status
             echo ""
             read -p "Press Enter to continue..."
             ;;
         5)
+            echo ""
+            retrieve_connection_info
+            echo ""
+            read -p "Press Enter to continue..."
+            ;;
+        6)
             echo "Exiting..."
             clear
             exit 0
             ;;
         *)
             echo ""
-            echo "Invalid option. Please select 1-5."
+            echo "Invalid option. Please select 1-6."
             echo ""
             read -p "Press Enter to continue..."
             ;;

--- a/instructions/cosmosdb/02-build-semantic-search.md
+++ b/instructions/cosmosdb/02-build-semantic-search.md
@@ -258,75 +258,49 @@ In this section you complete the *vector_functions.py* file by adding functions 
 
 1. Take a few minutes to review all of the code in the file.
 
-### Complete the setup container code
+### Review the setup container code
 
-In this section you complete the *setup_container.py* script used to create a Cosmos DB container with vector embedding and indexing policies. These policies enable the **VectorDistance** function for similarity search.
+In this section you review the *setup_container.py* script used to create a Cosmos DB container with vector embedding and indexing policies. The deployment script already created the container with these policies, but reviewing the code helps you understand the configuration.
 
 1. Open the *client/setup_container.py* file in VS Code.
 
-1. Search for the **BEGIN CREATE VECTOR CONTAINER FUNCTION** comment and review the code. This function creates a container configured for vector search:
+1. Search for the **BEGIN CREATE VECTOR CONTAINER FUNCTION** comment and review the code. Notice the two key policy configurations:
 
     ```python
-    def create_vector_container():
-        """
-        Create a container with vector embedding and indexing policies.
+    # Define the vector embedding policy
+    # This tells Cosmos DB how to handle vector data at the /embedding path
+    vector_embedding_policy = {
+        "vectorEmbeddings": [
+            {
+                "path": "/embedding",
+                "dataType": "float32",
+                "distanceFunction": "cosine",
+                "dimensions": 256
+            }
+        ]
+    }
 
-        The vector embedding policy defines:
-        - path: JSON path where vector embeddings are stored
-        - dataType: Data type for vector components (float32)
-        - distanceFunction: Similarity metric (cosine: 0=identical, 2=opposite)
-        - dimensions: Number of dimensions in each vector (256)
+    # Define the indexing policy with vector index
+    # - DiskANN provides efficient approximate nearest neighbor search
+    # - Exclude /embedding/* from standard indexing (vectors use their own index)
+    indexing_policy = {
+        "indexingMode": "consistent",
+        "automatic": True,
+        "includedPaths": [{"path": "/*"}],
+        "excludedPaths": [{"path": "/embedding/*"}],
+        "vectorIndexes": [
+            {"path": "/embedding", "type": "diskANN"}
+        ]
+    }
 
-        The indexing policy includes:
-        - Standard indexing for all paths except embeddings
-        - DiskANN vector index for efficient similarity search
-        """
-        database = get_database()
-        container_name = os.environ.get("COSMOS_CONTAINER", "vectors")
-
-        # Define the vector embedding policy
-        # This tells Cosmos DB how to handle vector data at the /embedding path
-        vector_embedding_policy = {
-            "vectorEmbeddings": [
-                {
-                    "path": "/embedding",
-                    "dataType": "float32",
-                    "distanceFunction": "cosine",
-                    "dimensions": 256
-                }
-            ]
-        }
-
-        # Define the indexing policy with vector index
-        # - DiskANN provides efficient approximate nearest neighbor search
-        # - Exclude /embedding/* from standard indexing (vectors use their own index)
-        indexing_policy = {
-            "indexingMode": "consistent",
-            "automatic": True,
-            "includedPaths": [
-                {"path": "/*"}
-            ],
-            "excludedPaths": [
-                {"path": "/embedding/*"}
-            ],
-            "vectorIndexes": [
-                {
-                    "path": "/embedding",
-                    "type": "diskANN"
-                }
-            ]
-        }
-
-        # Create the container with vector policies
-        # partition_key determines how data is distributed across physical partitions
-        container = database.create_container_if_not_exists(
-            id=container_name,
-            partition_key=PartitionKey(path="/documentId"),
-            indexing_policy=indexing_policy,
-            vector_embedding_policy=vector_embedding_policy
-        )
-
-        return container
+    # Create the container with vector policies
+    # partition_key determines how data is distributed across physical partitions
+    container = database.create_container_if_not_exists(
+        id=container_name,
+        partition_key=PartitionKey(path="/documentId"),
+        indexing_policy=indexing_policy,
+        vector_embedding_policy=vector_embedding_policy
+    )
     ```
 
 1. Take a moment to understand the key configuration elements:
@@ -344,15 +318,17 @@ Next, you finalize the Azure resource deployment.
 
 ## Complete the Azure resource deployment
 
-In this section you return to the deployment script to configure Entra ID access and retrieve the connection information.
+In this section you return to the deployment script to create the container, configure Entra ID access, and retrieve the connection information.
 
-1. When the **Create Cosmos DB account** operation has completed, enter **2** to launch the **Configure Entra ID access** option. This assigns your user account the necessary role to access the Cosmos DB data plane.
+1. When the **Create Cosmos DB account** operation has completed, enter **2** to launch the **Create container** option. This creates the vector container with the embedding and indexing policies needed for similarity search.
 
-1. Enter **3** to launch the **Check deployment status** option. Verify the Cosmos DB account shows as ready with the vector search capability enabled.
+1. Enter **3** to launch the **Configure Entra ID access** option. This assigns your user account the necessary role to access the Cosmos DB data plane.
 
-1. Enter **4** to launch the **Retrieve connection info** option. This creates a file with the necessary environment variables.
+1. Enter **4** to launch the **Check deployment status** option. Verify the Cosmos DB account shows as ready with the vector search capability enabled.
 
-1. Enter **5** to exit the deployment script.
+1. Enter **5** to launch the **Retrieve connection info** option. This creates a file with the necessary environment variables.
+
+1. Enter **6** to exit the deployment script.
 
 1. Run the following command to load the environment variables into your terminal session from the file created in a previous step.
 
@@ -368,7 +344,7 @@ In this section you return to the deployment script to configure Entra ID access
 
     >**Note:** Keep the terminal open. If you close it and create a new terminal, you might need to run the command to create the environment variable again.
 
-Next, you set up the Python environment and create the vector container.
+Next, you set up the Python environment and run the application.
 
 ## Set up the Python environment
 
@@ -403,20 +379,6 @@ In this section you create a Python virtual environment and install the dependen
     ```bash
     pip install -r requirements.txt
     ```
-
-Next, you create the vector container with the required policies.
-
-## Create the vector container
-
-In this section you run the setup script to create the Cosmos DB container with the vector policies you reviewed earlier.
-
-1. Run the following command to execute the setup script and create the container. Ensure you are still in the *client* directory with the virtual environment activated.
-
-    ```bash
-    python setup_container.py
-    ```
-
-1. Verify the output shows the container was created successfully with the vector policies configured.
 
 Next, you test the vector search functions using the Flask application.
 
@@ -497,13 +459,13 @@ If you encounter issues during this exercise, try these steps:
 - Ensure you are in the *client* directory when running **python app.py**
 
 **Authentication or access denied errors**
-- Ensure Entra ID access was configured by running the deployment script option **2**
+- Ensure Entra ID access was configured by running the deployment script option **3**
 - Verify your user has both the **Contributor** role and the **Cosmos DB Built-in Data Contributor** role
 - Ensure **COSMOS_ENDPOINT** is set correctly in your terminal session
 
 **Vector search returns no results or errors**
-- Verify the vector container was created by running **python setup_container.py**
-- Ensure the container has the vector embedding policy configured (check status with deployment script option **3**)
+- Verify the vector container was created by running the deployment script option **2**
+- Ensure the container has the vector embedding policy configured (check status with deployment script option **4**)
 - Verify sample tickets were loaded before running searches
 
 **setup_container.py fails**
@@ -512,12 +474,12 @@ If you encounter issues during this exercise, try these steps:
 - If container already exists, the script will use the existing container
 
 **Cosmos DB operations fail**
-- Verify the Cosmos DB account is ready by running the deployment script option **3**
+- Verify the Cosmos DB account is ready by running the deployment script option **4**
 - Ensure the database was created during deployment
 - Check that the account has the **EnableNoSQLVectorSearch** capability
 
 **Environment variable issues**
-- Ensure the *.env* file was created by running the deployment script option **4**
+- Ensure the *.env* file was created by running the deployment script option **5**
 - Run **source .env** (Bash) or **. .\.env.ps1** (PowerShell) after creating a new terminal
 - Verify variables are set by running **echo $COSMOS_ENDPOINT** (Bash) or **$env:COSMOS_ENDPOINT** (PowerShell)
 

--- a/instructions/cosmosdb/03-optimize-query-performance.md
+++ b/instructions/cosmosdb/03-optimize-query-performance.md
@@ -312,15 +312,17 @@ Next, you finalize the Azure resource deployment.
 
 ## Complete the Azure resource deployment
 
-In this section you return to the deployment script to configure Entra ID access and retrieve the connection information.
+In this section you return to the deployment script to create the containers, configure Entra ID access, and retrieve the connection information.
 
-1. When the **Create Cosmos DB account** operation has completed, enter **2** to launch the **Configure Entra ID access** option. This assigns your user account the necessary role to access the Cosmos DB data plane.
+1. When the **Create Cosmos DB account** operation has completed, enter **2** to launch the **Create containers** option. This creates three containers with different vector indexing strategies: flat, quantizedFlat, and diskANN.
 
-1. Enter **3** to launch the **Check deployment status** option. Verify the Cosmos DB account shows as ready with the vector search capability enabled.
+1. Enter **3** to launch the **Configure Entra ID access** option. This assigns your user account the necessary role to access the Cosmos DB data plane.
 
-1. Enter **4** to launch the **Retrieve connection info** option. This creates a file with the necessary environment variables.
+1. Enter **4** to launch the **Check deployment status** option. Verify the Cosmos DB account shows as ready with the vector search capability enabled.
 
-1. Enter **5** to exit the deployment script.
+1. Enter **5** to launch the **Retrieve connection info** option. This creates a file with the necessary environment variables.
+
+1. Enter **6** to exit the deployment script.
 
 1. Run the following command to load the environment variables into your terminal session from the file created in a previous step.
 
@@ -336,7 +338,7 @@ In this section you return to the deployment script to configure Entra ID access
 
     >**Note:** Keep the terminal open. If you close it and create a new terminal, you might need to run the command to create the environment variable again.
 
-Next, you set up the Python environment and create the vector containers.
+Next, you set up the Python environment and run the application.
 
 ## Set up the Python environment
 
@@ -371,23 +373,6 @@ In this section you create a Python virtual environment and install the dependen
     ```bash
     pip install -r requirements.txt
     ```
-
-Next, you create the containers with different vector indexing strategies.
-
-## Create containers with different index strategies
-
-In this section you run the setup script to create three Cosmos DB containers, each with a different vector indexing configuration. This enables side-by-side performance comparison.
-
-1. Run the following command to execute the setup script and create the containers. Ensure you are still in the *client* directory with the virtual environment activated.
-
-    ```bash
-    python setup_containers.py
-    ```
-
-1. Verify the output shows all three containers were created successfully:
-    - **vectors-flat** with flat index
-    - **vectors-quantized** with quantizedFlat index
-    - **vectors-diskann** with diskANN index
 
 Next, you test the vector index performance using the Flask application.
 
@@ -491,7 +476,7 @@ If you encounter issues during this exercise, try these steps:
 - Ensure you are in the *client* directory when running **python app.py**
 
 **Authentication or access denied errors**
-- Ensure Entra ID access was configured by running the deployment script option **2**
+- Ensure Entra ID access was configured by running the deployment script option **3**
 - Verify your user has both the **Contributor** role and the **Cosmos DB Built-in Data Contributor** role
 - Ensure **COSMOS_ENDPOINT** is set correctly in your terminal session
 
@@ -501,17 +486,17 @@ If you encounter issues during this exercise, try these steps:
 - If containers already exist, the script will use the existing containers
 
 **Vector search returns errors**
-- Verify the containers were created by running **python setup_containers.py**
+- Verify the containers were created by running the deployment script option **2**
 - Ensure sample data was loaded before running searches
 - Check that the containers have the vector embedding policy configured
 
 **Cosmos DB operations fail**
-- Verify the Cosmos DB account is ready by running the deployment script option **3**
+- Verify the Cosmos DB account is ready by running the deployment script option **4**
 - Ensure the database was created during deployment
 - Check that the account has the **EnableNoSQLVectorSearch** capability
 
 **Environment variable issues**
-- Ensure the *.env* file was created by running the deployment script option **4**
+- Ensure the *.env* file was created by running the deployment script option **5**
 - Run **source .env** (Bash) or **. .\.env.ps1** (PowerShell) after creating a new terminal
 - Verify variables are set by running **echo $COSMOS_ENDPOINT** (Bash) or **$env:COSMOS_ENDPOINT** (PowerShell)
 

--- a/starter/cosmosdb/implement-vector/python/azdeploy.ps1
+++ b/starter/cosmosdb/implement-vector/python/azdeploy.ps1
@@ -88,7 +88,72 @@ function Create-CosmosDBAccount {
     }
 
     Write-Host ""
-    Write-Host "Use option 2 to configure Entra ID access."
+    Write-Host "Use option 2 to create the container."
+}
+
+# Function to create container with vector embedding and indexing policies
+function Create-Containers {
+    Write-Host "Creating container with vector search policies..."
+
+    # Prereq check: Cosmos DB account must exist and be ready
+    $status = (az cosmosdb show --resource-group $rg --name $accountName --query "provisioningState" -o tsv 2>$null)
+    if ([string]::IsNullOrWhiteSpace($status)) {
+        Write-Host "Error: Cosmos DB account '$accountName' not found."
+        Write-Host "Please run option 1 to create the Cosmos DB account, then try again."
+        return
+    }
+
+    if ($status -ne "Succeeded") {
+        Write-Host "Error: Cosmos DB account is not ready (current state: $status)."
+        Write-Host "Please wait for deployment to complete. Use option 4 to check status."
+        return
+    }
+
+    # Check if container already exists
+    az cosmosdb sql container show `
+        --resource-group $rg `
+        --account-name $accountName `
+        --database-name $databaseName `
+        --name $containerName 2>$null | Out-Null
+
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "$([char]0x2713) Container already exists: $containerName"
+        return
+    }
+
+    # Create container with vector embedding policy and indexing policy (DiskANN)
+    $indexingPolicy = '{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/embedding/*"}],"vectorIndexes":[{"path":"/embedding","type":"diskANN"}]}'
+    $vectorPolicy = '{"vectorEmbeddings":[{"path":"/embedding","dataType":"float32","distanceFunction":"cosine","dimensions":256}]}'
+
+    az cosmosdb sql container create `
+        --resource-group $rg `
+        --account-name $accountName `
+        --database-name $databaseName `
+        --name $containerName `
+        --partition-key-path "/documentId" `
+        --idx $indexingPolicy `
+        --vector-embeddings $vectorPolicy 2>$null | Out-Null
+
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "$([char]0x2713) Container created: $containerName"
+        Write-Host ""
+        Write-Host "  Vector embedding policy:"
+        Write-Host "    - Path: /embedding"
+        Write-Host "    - Data type: float32"
+        Write-Host "    - Distance function: cosine"
+        Write-Host "    - Dimensions: 256"
+        Write-Host ""
+        Write-Host "  Indexing policy:"
+        Write-Host "    - Vector index type: diskANN"
+        Write-Host "    - Embedding path excluded from standard indexing"
+    }
+    else {
+        Write-Host "Error: Failed to create container"
+        return
+    }
+
+    Write-Host ""
+    Write-Host "Use option 3 to configure Entra ID access."
 }
 
 # Function to configure Entra ID RBAC for the signed-in user
@@ -105,7 +170,7 @@ function Configure-EntraAccess {
 
     if ($status -ne "Succeeded") {
         Write-Host "Error: Cosmos DB account is not ready (current state: $status)."
-        Write-Host "Please wait for deployment to complete. Use option 3 to check status."
+        Write-Host "Please wait for deployment to complete. Use option 4 to check status."
         return
     }
 
@@ -220,6 +285,15 @@ function Check-DeploymentStatus {
                 Write-Host "  $([char]0x26A0) Database not created"
             }
 
+            # Check container
+            az cosmosdb sql container show --resource-group $rg --account-name $accountName --database-name $databaseName --name $containerName 2>$null | Out-Null
+            if ($LASTEXITCODE -eq 0) {
+                Write-Host "  $([char]0x2713) Container: $containerName"
+            }
+            else {
+                Write-Host "  $([char]0x26A0) Container not created"
+            }
+
             # Check Entra ID RBAC
             $userUpn = (az ad signed-in-user show --query userPrincipalName -o tsv 2>$null)
             $accountId = (az cosmosdb show --resource-group $rg --name $accountName --query "id" -o tsv)
@@ -276,7 +350,7 @@ function Retrieve-ConnectionInfo {
 
     if ([string]::IsNullOrWhiteSpace($cosmosRole)) {
         Write-Host "Error: Entra ID access not configured for this account."
-        Write-Host "Please run option 2 to configure Entra ID access, then try again."
+        Write-Host "Please run option 3 to configure Entra ID access, then try again."
         return
     }
 
@@ -320,17 +394,18 @@ function Show-Menu {
     Write-Host "Location: $location"
     Write-Host "====================================================================="
     Write-Host "1. Create Cosmos DB account (with vector search capability)"
-    Write-Host "2. Configure Entra ID access"
-    Write-Host "3. Check deployment status"
-    Write-Host "4. Retrieve connection info"
-    Write-Host "5. Exit"
+    Write-Host "2. Create container (with vector indexing policies)"
+    Write-Host "3. Configure Entra ID access"
+    Write-Host "4. Check deployment status"
+    Write-Host "5. Retrieve connection info"
+    Write-Host "6. Exit"
     Write-Host "====================================================================="
 }
 
 # Main menu loop
 while ($true) {
     Show-Menu
-    $choice = Read-Host "Please select an option (1-5)"
+    $choice = Read-Host "Please select an option (1-6)"
 
     switch ($choice) {
         "1" {
@@ -343,30 +418,36 @@ while ($true) {
         }
         "2" {
             Write-Host ""
-            Configure-EntraAccess
+            Create-Containers
             Write-Host ""
             Read-Host "Press Enter to continue..."
         }
         "3" {
             Write-Host ""
-            Check-DeploymentStatus
+            Configure-EntraAccess
             Write-Host ""
             Read-Host "Press Enter to continue..."
         }
         "4" {
             Write-Host ""
-            Retrieve-ConnectionInfo
+            Check-DeploymentStatus
             Write-Host ""
             Read-Host "Press Enter to continue..."
         }
         "5" {
+            Write-Host ""
+            Retrieve-ConnectionInfo
+            Write-Host ""
+            Read-Host "Press Enter to continue..."
+        }
+        "6" {
             Write-Host "Exiting..."
             Clear-Host
             exit 0
         }
         default {
             Write-Host ""
-            Write-Host "Invalid option. Please select 1-5."
+            Write-Host "Invalid option. Please select 1-6."
             Write-Host ""
             Read-Host "Press Enter to continue..."
         }

--- a/starter/cosmosdb/implement-vector/python/azdeploy.sh
+++ b/starter/cosmosdb/implement-vector/python/azdeploy.sh
@@ -80,7 +80,68 @@ create_cosmosdb_account() {
     fi
 
     echo ""
-    echo "Use option 2 to configure Entra ID access."
+    echo "Use option 2 to create the container."
+}
+
+# Function to create container with vector embedding and indexing policies
+create_containers() {
+    echo "Creating container with vector search policies..."
+
+    # Prereq check: Cosmos DB account must exist and be ready
+    local status=$(az cosmosdb show --resource-group $rg --name $account_name --query "provisioningState" -o tsv 2>/dev/null)
+    if [ -z "$status" ]; then
+        echo "Error: Cosmos DB account '$account_name' not found."
+        echo "Please run option 1 to create the Cosmos DB account, then try again."
+        return 1
+    fi
+
+    if [ "$status" != "Succeeded" ]; then
+        echo "Error: Cosmos DB account is not ready (current state: $status)."
+        echo "Please wait for deployment to complete. Use option 4 to check status."
+        return 1
+    fi
+
+    # Check if container already exists
+    local container_exists=$(az cosmosdb sql container show \
+        --resource-group $rg \
+        --account-name $account_name \
+        --database-name $database_name \
+        --name $container_name 2>/dev/null)
+
+    if [ -n "$container_exists" ]; then
+        echo "✓ Container already exists: $container_name"
+        return 0
+    fi
+
+    # Create container with vector embedding policy and indexing policy (DiskANN)
+    az cosmosdb sql container create \
+        --resource-group $rg \
+        --account-name $account_name \
+        --database-name $database_name \
+        --name $container_name \
+        --partition-key-path "/documentId" \
+        --idx '{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/embedding/*"}],"vectorIndexes":[{"path":"/embedding","type":"diskANN"}]}' \
+        --vector-embeddings '{"vectorEmbeddings":[{"path":"/embedding","dataType":"float32","distanceFunction":"cosine","dimensions":256}]}' > /dev/null 2>&1
+
+    if [ $? -eq 0 ]; then
+        echo "✓ Container created: $container_name"
+        echo ""
+        echo "  Vector embedding policy:"
+        echo "    - Path: /embedding"
+        echo "    - Data type: float32"
+        echo "    - Distance function: cosine"
+        echo "    - Dimensions: 256"
+        echo ""
+        echo "  Indexing policy:"
+        echo "    - Vector index type: diskANN"
+        echo "    - Embedding path excluded from standard indexing"
+    else
+        echo "Error: Failed to create container"
+        return 1
+    fi
+
+    echo ""
+    echo "Use option 3 to configure Entra ID access."
 }
 
 # Function to configure Entra ID RBAC for the signed-in user
@@ -195,7 +256,7 @@ retrieve_connection_info() {
 
     if [ -z "$cosmos_role" ]; then
         echo "Error: Entra ID access not configured for this account."
-        echo "Please run option 2 to configure Entra ID access, then try again."
+        echo "Please run option 3 to configure Entra ID access, then try again."
         return 1
     fi
 
@@ -259,6 +320,14 @@ check_deployment_status() {
                 echo "  ⚠ Database not created"
             fi
 
+            # Check container
+            local container_status=$(az cosmosdb sql container show --resource-group $rg --account-name $account_name --database-name $database_name --name $container_name 2>/dev/null)
+            if [ -n "$container_status" ]; then
+                echo "  ✓ Container: $container_name"
+            else
+                echo "  ⚠ Container not created"
+            fi
+
             # Check Entra ID RBAC
             local user_upn=$(az ad signed-in-user show --query userPrincipalName -o tsv 2>/dev/null)
             local account_id=$(az cosmosdb show --resource-group $rg --name $account_name --query "id" -o tsv)
@@ -301,17 +370,18 @@ show_menu() {
     echo "Location: $location"
     echo "====================================================================="
     echo "1. Create Cosmos DB account (with vector search capability)"
-    echo "2. Configure Entra ID access"
-    echo "3. Check deployment status"
-    echo "4. Retrieve connection info"
-    echo "5. Exit"
+    echo "2. Create container (with vector indexing policies)"
+    echo "3. Configure Entra ID access"
+    echo "4. Check deployment status"
+    echo "5. Retrieve connection info"
+    echo "6. Exit"
     echo "====================================================================="
 }
 
 # Main menu loop
 while true; do
     show_menu
-    read -p "Please select an option (1-5): " choice
+    read -p "Please select an option (1-6): " choice
 
     case $choice in
         1)
@@ -324,30 +394,36 @@ while true; do
             ;;
         2)
             echo ""
-            configure_entra_access
+            create_containers
             echo ""
             read -p "Press Enter to continue..."
             ;;
         3)
             echo ""
-            check_deployment_status
+            configure_entra_access
             echo ""
             read -p "Press Enter to continue..."
             ;;
         4)
             echo ""
-            retrieve_connection_info
+            check_deployment_status
             echo ""
             read -p "Press Enter to continue..."
             ;;
         5)
+            echo ""
+            retrieve_connection_info
+            echo ""
+            read -p "Press Enter to continue..."
+            ;;
+        6)
             echo "Exiting..."
             clear
             exit 0
             ;;
         *)
             echo ""
-            echo "Invalid option. Please select 1-5."
+            echo "Invalid option. Please select 1-6."
             echo ""
             read -p "Press Enter to continue..."
             ;;

--- a/starter/cosmosdb/optimize-query/python/azdeploy.ps1
+++ b/starter/cosmosdb/optimize-query/python/azdeploy.ps1
@@ -87,7 +87,80 @@ function Create-CosmosDBAccount {
     }
 
     Write-Host ""
-    Write-Host "Use option 2 to configure Entra ID access."
+    Write-Host "Use option 2 to create the containers."
+}
+
+# Function to create containers with different vector indexing strategies
+function Create-Containers {
+    Write-Host "Creating containers with vector indexing policies..."
+
+    # Prereq check: Cosmos DB account must exist and be ready
+    $status = (az cosmosdb show --resource-group $rg --name $accountName --query "provisioningState" -o tsv 2>$null)
+    if ([string]::IsNullOrWhiteSpace($status)) {
+        Write-Host "Error: Cosmos DB account '$accountName' not found."
+        Write-Host "Please run option 1 to create the Cosmos DB account, then try again."
+        return
+    }
+
+    if ($status -ne "Succeeded") {
+        Write-Host "Error: Cosmos DB account is not ready (current state: $status)."
+        Write-Host "Please wait for deployment to complete. Use option 4 to check status."
+        return
+    }
+
+    $vectorPolicy = '{"vectorEmbeddings":[{"path":"/embedding","dataType":"float32","distanceFunction":"cosine","dimensions":256}]}'
+    $created = 0
+
+    # Define containers: name and index type
+    $containers = @(
+        @{ Name = "vectors-flat"; Type = "flat"; Description = "exact nearest neighbor" },
+        @{ Name = "vectors-quantized"; Type = "quantizedFlat"; Description = "compressed exact search" },
+        @{ Name = "vectors-diskann"; Type = "diskANN"; Description = "approximate nearest neighbor" }
+    )
+
+    foreach ($container in $containers) {
+        az cosmosdb sql container show --resource-group $rg --account-name $accountName --database-name $databaseName --name $container.Name 2>$null | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "$([char]0x2713) Container already exists: $($container.Name)"
+        }
+        else {
+            Write-Host "Creating container '$($container.Name)' with $($container.Type) vector index..."
+            $indexingPolicy = '{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/embedding/*"}],"vectorIndexes":[{"path":"/embedding","type":"' + $container.Type + '"}]}'
+
+            az cosmosdb sql container create `
+                --resource-group $rg `
+                --account-name $accountName `
+                --database-name $databaseName `
+                --name $container.Name `
+                --partition-key-path "/documentId" `
+                --idx $indexingPolicy `
+                --vector-embeddings $vectorPolicy 2>$null | Out-Null
+
+            if ($LASTEXITCODE -eq 0) {
+                Write-Host "$([char]0x2713) Container created: $($container.Name) ($($container.Description))"
+                $created++
+            }
+            else {
+                Write-Host "Error: Failed to create container $($container.Name)"
+                return
+            }
+        }
+    }
+
+    if ($created -gt 0) {
+        Write-Host ""
+        Write-Host "All containers share:"
+        Write-Host "  - Partition key: /documentId"
+        Write-Host "  - Vector embedding: /embedding (float32, cosine, 256 dimensions)"
+        Write-Host ""
+        Write-Host "Index types:"
+        Write-Host "  - vectors-flat: flat (exact search)"
+        Write-Host "  - vectors-quantized: quantizedFlat (compressed exact search)"
+        Write-Host "  - vectors-diskann: diskANN (approximate nearest neighbor)"
+    }
+
+    Write-Host ""
+    Write-Host "Use option 3 to configure Entra ID access."
 }
 
 # Function to configure Entra ID RBAC for the signed-in user
@@ -104,7 +177,7 @@ function Configure-EntraAccess {
 
     if ($status -ne "Succeeded") {
         Write-Host "Error: Cosmos DB account is not ready (current state: $status)."
-        Write-Host "Please wait for deployment to complete. Use option 3 to check status."
+        Write-Host "Please wait for deployment to complete. Use option 4 to check status."
         return
     }
 
@@ -219,6 +292,17 @@ function Check-DeploymentStatus {
                 Write-Host "  $([char]0x26A0) Database not created"
             }
 
+            # Check containers
+            foreach ($cname in @("vectors-flat", "vectors-quantized", "vectors-diskann")) {
+                az cosmosdb sql container show --resource-group $rg --account-name $accountName --database-name $databaseName --name $cname 2>$null | Out-Null
+                if ($LASTEXITCODE -eq 0) {
+                    Write-Host "  $([char]0x2713) Container: $cname"
+                }
+                else {
+                    Write-Host "  $([char]0x26A0) Container not created: $cname"
+                }
+            }
+
             # Check Entra ID RBAC
             $userUpn = (az ad signed-in-user show --query userPrincipalName -o tsv 2>$null)
             $accountId = (az cosmosdb show --resource-group $rg --name $accountName --query "id" -o tsv)
@@ -275,7 +359,7 @@ function Retrieve-ConnectionInfo {
 
     if ([string]::IsNullOrWhiteSpace($cosmosRole)) {
         Write-Host "Error: Entra ID access not configured for this account."
-        Write-Host "Please run option 2 to configure Entra ID access, then try again."
+        Write-Host "Please run option 3 to configure Entra ID access, then try again."
         return
     }
 
@@ -291,7 +375,6 @@ function Retrieve-ConnectionInfo {
     $envFile = Join-Path $scriptDir ".env.ps1"
 
     # Create or update .env.ps1 file with environment variable assignments (no key needed for Entra auth)
-    # Note: Containers are created by setup_containers.py with different index types
     @(
         "`$env:COSMOS_ENDPOINT = `"$endpoint`"",
         "`$env:COSMOS_DATABASE = `"$databaseName`""
@@ -304,7 +387,7 @@ function Retrieve-ConnectionInfo {
     Write-Host "Database: $databaseName"
     Write-Host "Authentication: Microsoft Entra ID (DefaultAzureCredential)"
     Write-Host ""
-    Write-Host "Note: Containers will be created by setup_containers.py"
+    Write-Host "Containers: vectors-flat, vectors-quantized, vectors-diskann"
     Write-Host ""
     Write-Host "Environment variables saved to: $envFile"
 }
@@ -320,17 +403,18 @@ function Show-Menu {
     Write-Host "Location: $location"
     Write-Host "====================================================================="
     Write-Host "1. Create Cosmos DB account (with vector search capability)"
-    Write-Host "2. Configure Entra ID access"
-    Write-Host "3. Check deployment status"
-    Write-Host "4. Retrieve connection info"
-    Write-Host "5. Exit"
+    Write-Host "2. Create containers (with vector indexing policies)"
+    Write-Host "3. Configure Entra ID access"
+    Write-Host "4. Check deployment status"
+    Write-Host "5. Retrieve connection info"
+    Write-Host "6. Exit"
     Write-Host "====================================================================="
 }
 
 # Main menu loop
 while ($true) {
     Show-Menu
-    $choice = Read-Host "Please select an option (1-5)"
+    $choice = Read-Host "Please select an option (1-6)"
 
     switch ($choice) {
         "1" {
@@ -343,30 +427,36 @@ while ($true) {
         }
         "2" {
             Write-Host ""
-            Configure-EntraAccess
+            Create-Containers
             Write-Host ""
             Read-Host "Press Enter to continue..."
         }
         "3" {
             Write-Host ""
-            Check-DeploymentStatus
+            Configure-EntraAccess
             Write-Host ""
             Read-Host "Press Enter to continue..."
         }
         "4" {
             Write-Host ""
-            Retrieve-ConnectionInfo
+            Check-DeploymentStatus
             Write-Host ""
             Read-Host "Press Enter to continue..."
         }
         "5" {
+            Write-Host ""
+            Retrieve-ConnectionInfo
+            Write-Host ""
+            Read-Host "Press Enter to continue..."
+        }
+        "6" {
             Write-Host "Exiting..."
             Clear-Host
             exit 0
         }
         default {
             Write-Host ""
-            Write-Host "Invalid option. Please select 1-5."
+            Write-Host "Invalid option. Please select 1-6."
             Write-Host ""
             Read-Host "Press Enter to continue..."
         }

--- a/starter/cosmosdb/optimize-query/python/azdeploy.sh
+++ b/starter/cosmosdb/optimize-query/python/azdeploy.sh
@@ -79,7 +79,116 @@ create_cosmosdb_account() {
     fi
 
     echo ""
-    echo "Use option 2 to configure Entra ID access."
+    echo "Use option 2 to create the containers."
+}
+
+# Function to create containers with different vector indexing strategies
+create_containers() {
+    echo "Creating containers with vector indexing policies..."
+
+    # Prereq check: Cosmos DB account must exist and be ready
+    local status=$(az cosmosdb show --resource-group $rg --name $account_name --query "provisioningState" -o tsv 2>/dev/null)
+    if [ -z "$status" ]; then
+        echo "Error: Cosmos DB account '$account_name' not found."
+        echo "Please run option 1 to create the Cosmos DB account, then try again."
+        return 1
+    fi
+
+    if [ "$status" != "Succeeded" ]; then
+        echo "Error: Cosmos DB account is not ready (current state: $status)."
+        echo "Please wait for deployment to complete. Use option 4 to check status."
+        return 1
+    fi
+
+    local vector_policy='{"vectorEmbeddings":[{"path":"/embedding","dataType":"float32","distanceFunction":"cosine","dimensions":256}]}'
+    local created=0
+
+    # Create vectors-flat container (exact nearest neighbor search)
+    local exists=$(az cosmosdb sql container show --resource-group $rg --account-name $account_name --database-name $database_name --name "vectors-flat" 2>/dev/null)
+    if [ -n "$exists" ]; then
+        echo "✓ Container already exists: vectors-flat"
+    else
+        echo "Creating container 'vectors-flat' with flat vector index..."
+        az cosmosdb sql container create \
+            --resource-group $rg \
+            --account-name $account_name \
+            --database-name $database_name \
+            --name "vectors-flat" \
+            --partition-key-path "/documentId" \
+            --idx '{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/embedding/*"}],"vectorIndexes":[{"path":"/embedding","type":"flat"}]}' \
+            --vector-embeddings "$vector_policy" > /dev/null 2>&1
+
+        if [ $? -eq 0 ]; then
+            echo "✓ Container created: vectors-flat (exact nearest neighbor)"
+            created=$((created + 1))
+        else
+            echo "Error: Failed to create container vectors-flat"
+            return 1
+        fi
+    fi
+
+    # Create vectors-quantized container (compressed exact search)
+    exists=$(az cosmosdb sql container show --resource-group $rg --account-name $account_name --database-name $database_name --name "vectors-quantized" 2>/dev/null)
+    if [ -n "$exists" ]; then
+        echo "✓ Container already exists: vectors-quantized"
+    else
+        echo "Creating container 'vectors-quantized' with quantizedFlat vector index..."
+        az cosmosdb sql container create \
+            --resource-group $rg \
+            --account-name $account_name \
+            --database-name $database_name \
+            --name "vectors-quantized" \
+            --partition-key-path "/documentId" \
+            --idx '{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/embedding/*"}],"vectorIndexes":[{"path":"/embedding","type":"quantizedFlat"}]}' \
+            --vector-embeddings "$vector_policy" > /dev/null 2>&1
+
+        if [ $? -eq 0 ]; then
+            echo "✓ Container created: vectors-quantized (compressed exact search)"
+            created=$((created + 1))
+        else
+            echo "Error: Failed to create container vectors-quantized"
+            return 1
+        fi
+    fi
+
+    # Create vectors-diskann container (approximate nearest neighbor)
+    exists=$(az cosmosdb sql container show --resource-group $rg --account-name $account_name --database-name $database_name --name "vectors-diskann" 2>/dev/null)
+    if [ -n "$exists" ]; then
+        echo "✓ Container already exists: vectors-diskann"
+    else
+        echo "Creating container 'vectors-diskann' with diskANN vector index..."
+        az cosmosdb sql container create \
+            --resource-group $rg \
+            --account-name $account_name \
+            --database-name $database_name \
+            --name "vectors-diskann" \
+            --partition-key-path "/documentId" \
+            --idx '{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/embedding/*"}],"vectorIndexes":[{"path":"/embedding","type":"diskANN"}]}' \
+            --vector-embeddings "$vector_policy" > /dev/null 2>&1
+
+        if [ $? -eq 0 ]; then
+            echo "✓ Container created: vectors-diskann (approximate nearest neighbor)"
+            created=$((created + 1))
+        else
+            echo "Error: Failed to create container vectors-diskann"
+            return 1
+        fi
+    fi
+
+    if [ $created -gt 0 ]; then
+        echo ""
+        echo "All containers share:"
+        echo "  - Partition key: /documentId"
+        echo "  - Vector embedding: /embedding (float32, cosine, 256 dimensions)"
+        echo ""
+        echo "Index types:"
+        echo "  - vectors-flat: flat (exact search)"
+        echo "  - vectors-quantized: quantizedFlat (compressed exact search)"
+        echo "  - vectors-diskann: diskANN (approximate nearest neighbor)"
+    fi
+
+    echo ""
+    echo "Use option 3 to configure Entra ID access."
 }
 
 # Function to configure Entra ID RBAC for the signed-in user
@@ -194,7 +303,7 @@ retrieve_connection_info() {
 
     if [ -z "$cosmos_role" ]; then
         echo "Error: Entra ID access not configured for this account."
-        echo "Please run option 2 to configure Entra ID access, then try again."
+        echo "Please run option 3 to configure Entra ID access, then try again."
         return 1
     fi
 
@@ -209,7 +318,6 @@ retrieve_connection_info() {
     local env_file="$(dirname "$0")/.env"
 
     # Create or update .env file with export statements (no key needed for Entra auth)
-    # Note: Containers are created by setup_containers.py with different index types
     cat > "$env_file" << EOF
 export COSMOS_ENDPOINT="$endpoint"
 export COSMOS_DATABASE="$database_name"
@@ -222,7 +330,7 @@ EOF
     echo "Database: $database_name"
     echo "Authentication: Microsoft Entra ID (DefaultAzureCredential)"
     echo ""
-    echo "Note: Containers will be created by setup_containers.py"
+    echo "Containers: vectors-flat, vectors-quantized, vectors-diskann"
     echo ""
     echo "Environment variables saved to: $env_file"
 }
@@ -258,6 +366,16 @@ check_deployment_status() {
             else
                 echo "  ⚠ Database not created"
             fi
+
+            # Check containers
+            for cname in "vectors-flat" "vectors-quantized" "vectors-diskann"; do
+                local c_status=$(az cosmosdb sql container show --resource-group $rg --account-name $account_name --database-name $database_name --name $cname 2>/dev/null)
+                if [ -n "$c_status" ]; then
+                    echo "  ✓ Container: $cname"
+                else
+                    echo "  ⚠ Container not created: $cname"
+                fi
+            done
 
             # Check Entra ID RBAC
             local user_upn=$(az ad signed-in-user show --query userPrincipalName -o tsv 2>/dev/null)
@@ -301,17 +419,18 @@ show_menu() {
     echo "Location: $location"
     echo "====================================================================="
     echo "1. Create Cosmos DB account (with vector search capability)"
-    echo "2. Configure Entra ID access"
-    echo "3. Check deployment status"
-    echo "4. Retrieve connection info"
-    echo "5. Exit"
+    echo "2. Create containers (with vector indexing policies)"
+    echo "3. Configure Entra ID access"
+    echo "4. Check deployment status"
+    echo "5. Retrieve connection info"
+    echo "6. Exit"
     echo "====================================================================="
 }
 
 # Main menu loop
 while true; do
     show_menu
-    read -p "Please select an option (1-5): " choice
+    read -p "Please select an option (1-6): " choice
 
     case $choice in
         1)
@@ -324,30 +443,36 @@ while true; do
             ;;
         2)
             echo ""
-            configure_entra_access
+            create_containers
             echo ""
             read -p "Press Enter to continue..."
             ;;
         3)
             echo ""
-            check_deployment_status
+            configure_entra_access
             echo ""
             read -p "Press Enter to continue..."
             ;;
         4)
             echo ""
-            retrieve_connection_info
+            check_deployment_status
             echo ""
             read -p "Press Enter to continue..."
             ;;
         5)
+            echo ""
+            retrieve_connection_info
+            echo ""
+            read -p "Press Enter to continue..."
+            ;;
+        6)
             echo "Exiting..."
             clear
             exit 0
             ;;
         *)
             echo ""
-            echo "Invalid option. Please select 1-5."
+            echo "Invalid option. Please select 1-6."
             echo ""
             read -p "Press Enter to continue..."
             ;;


### PR DESCRIPTION
Fixes #153 

Changes proposed in this pull request:

- Issue was the requirement for "Owner" permission in the subscription. Cosmos uses different auth paths for the CLI/ARM vs. the SDK. Anything less that "Owner" meant the container creation via python script would fail due to not having the necessary permissions in the SDK auth path.
-
-