### PR TITLE
fix for 178

### DIFF
--- a/finished/amr/data-operations/python/azdeploy.ps1
+++ b/finished/amr/data-operations/python/azdeploy.ps1
@@ -56,7 +56,6 @@ function Create-RedisResource {
         --location $location `
         --sku "Balanced_B0" `
         --public-network-access "Enabled" `
-        --access-keys-auth "Enabled" `
         --no-database `
         --no-wait
 

--- a/finished/amr/data-operations/python/azdeploy.sh
+++ b/finished/amr/data-operations/python/azdeploy.sh
@@ -53,7 +53,6 @@ create_redis_resource() {
         --location $location \
         --sku "Balanced_B0" \
         --public-network-access "Enabled" \
-        --access-keys-auth "Enabled" \
         --no-database \
         --no-wait
 

--- a/finished/amr/pub-sub/python/azdeploy.ps1
+++ b/finished/amr/pub-sub/python/azdeploy.ps1
@@ -56,7 +56,6 @@ function Create-RedisResource {
         --location $location `
         --sku "Balanced_B0" `
         --public-network-access "Enabled" `
-        --access-keys-auth "Enabled" `
         --no-database `
         --no-wait
 

--- a/finished/amr/pub-sub/python/azdeploy.sh
+++ b/finished/amr/pub-sub/python/azdeploy.sh
@@ -53,7 +53,6 @@ create_redis_resource() {
         --location $location \
         --sku "Balanced_B0" \
         --public-network-access "Enabled" \
-        --access-keys-auth "Enabled" \
         --no-database \
         --no-wait
 

--- a/finished/amr/vector-query/python/azdeploy.ps1
+++ b/finished/amr/vector-query/python/azdeploy.ps1
@@ -57,7 +57,6 @@ function Create-RedisResource {
         --location $location `
         --sku Enterprise_E10 `
         --public-network-access "Enabled" `
-        --access-keys-auth "Enabled" `
         --no-database `
         --no-wait
 

--- a/finished/amr/vector-query/python/azdeploy.sh
+++ b/finished/amr/vector-query/python/azdeploy.sh
@@ -54,7 +54,6 @@ create_redis_resource() {
         --location $location \
         --sku Enterprise_E10 \
         --public-network-access "Enabled" \
-        --access-keys-auth "Enabled" \
         --no-database \
         --no-wait
 

--- a/starter/amr/data-operations/python/azdeploy.ps1
+++ b/starter/amr/data-operations/python/azdeploy.ps1
@@ -53,7 +53,6 @@ function Create-RedisResource {
         --location $location `
         --sku "Balanced_B0" `
         --public-network-access "Enabled" `
-        --access-keys-auth "Enabled" `
         --no-database `
         --no-wait
 

--- a/starter/amr/data-operations/python/azdeploy.sh
+++ b/starter/amr/data-operations/python/azdeploy.sh
@@ -50,7 +50,6 @@ create_redis_resource() {
         --location $location \
         --sku "Balanced_B0" \
         --public-network-access "Enabled" \
-        --access-keys-auth "Enabled" \
         --no-database \
         --no-wait
 

--- a/starter/amr/pub-sub/python/azdeploy.ps1
+++ b/starter/amr/pub-sub/python/azdeploy.ps1
@@ -53,7 +53,6 @@ function Create-RedisResource {
         --location $location `
         --sku "Balanced_B0" `
         --public-network-access "Enabled" `
-        --access-keys-auth "Enabled" `
         --no-database `
         --no-wait
 

--- a/starter/amr/pub-sub/python/azdeploy.sh
+++ b/starter/amr/pub-sub/python/azdeploy.sh
@@ -50,7 +50,6 @@ create_redis_resource() {
         --location $location \
         --sku "Balanced_B0" \
         --public-network-access "Enabled" \
-        --access-keys-auth "Enabled" \
         --no-database \
         --no-wait
 

--- a/starter/amr/vector-query/python/azdeploy.ps1
+++ b/starter/amr/vector-query/python/azdeploy.ps1
@@ -54,7 +54,6 @@ function Create-RedisResource {
         --location $location `
         --sku Enterprise_E10 `
         --public-network-access "Enabled" `
-        --access-keys-auth "Enabled" `
         --no-database `
         --no-wait
 

--- a/starter/amr/vector-query/python/azdeploy.sh
+++ b/starter/amr/vector-query/python/azdeploy.sh
@@ -51,7 +51,6 @@ create_redis_resource() {
         --location $location \
         --sku Enterprise_E10 \
         --public-network-access "Enabled" \
-        --access-keys-auth "Enabled" \
         --no-database \
         --no-wait
 


### PR DESCRIPTION
Fixes #178 

Changes proposed in this pull request:

- Removed the --access-keys-auth "Enabled" flag from the az redisenterprise create call in all AMR deployment scripts (PowerShell and Bash, for data-operations, pub-sub, and vector-query).
- Recent versions of the redisenterprise CLI extension reject this database-level flag when combined with --no-database, which caused option 1 of azdeploy.ps1/azdeploy.sh to fail.
- Access-key auth is still enabled on the database itself by option 3, so student behavior and instructions are unchanged.