### PR TITLE
Updated deployment scripts to better handle failed role assignments.

### DIFF
--- a/finished/aks/deploy-aks/python/azdeploy.ps1
+++ b/finished/aks/deploy-aks/python/azdeploy.ps1
@@ -322,7 +322,11 @@ function Deploy-ToAKS {
         --role "Cognitive Services OpenAI User" `
         --scope $foundryResourceId 2>$null | Out-Null
 
-    Write-Host "$([char]0x2713) Role assigned to AKS kubelet identity"
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Error: Failed to assign Cognitive Services OpenAI User role. Re-run option 7 to try again."
+        return $false
+    }
+    Write-Host "$([char]0x2713) Role assigned to AKS kubelet identity (may take 1-2 minutes to propagate)"
     Write-Host ""
 
     # Update the deployment.yaml with the correct ACR endpoint and Foundry endpoint

--- a/finished/aks/deploy-aks/python/azdeploy.sh
+++ b/finished/aks/deploy-aks/python/azdeploy.sh
@@ -321,7 +321,11 @@ deploy_to_aks() {
         --role "Cognitive Services OpenAI User" \
         --scope "$foundry_resource_id" > /dev/null 2>&1
 
-    echo "✓ Role assigned to AKS kubelet identity"
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to assign Cognitive Services OpenAI User role. Re-run option 7 to try again."
+        return 1
+    fi
+    echo "✓ Role assigned to AKS kubelet identity (may take 1-2 minutes to propagate)"
     echo ""
 
     # Update the deployment.yaml with the correct ACR endpoint and Foundry endpoint

--- a/starter/aks/deploy-aks/python/azdeploy.ps1
+++ b/starter/aks/deploy-aks/python/azdeploy.ps1
@@ -319,7 +319,11 @@ function Deploy-ToAKS {
         --role "Cognitive Services OpenAI User" `
         --scope $foundryResourceId 2>$null | Out-Null
 
-    Write-Host "$([char]0x2713) Role assigned to AKS kubelet identity"
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Error: Failed to assign Cognitive Services OpenAI User role. Re-run option 7 to try again."
+        return $false
+    }
+    Write-Host "$([char]0x2713) Role assigned to AKS kubelet identity (may take 1-2 minutes to propagate)"
     Write-Host ""
 
     # Update the deployment.yaml with the correct ACR endpoint and Foundry endpoint

--- a/starter/aks/deploy-aks/python/azdeploy.sh
+++ b/starter/aks/deploy-aks/python/azdeploy.sh
@@ -318,7 +318,11 @@ deploy_to_aks() {
         --role "Cognitive Services OpenAI User" \
         --scope "$foundry_resource_id" > /dev/null 2>&1
 
-    echo "✓ Role assigned to AKS kubelet identity"
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to assign Cognitive Services OpenAI User role. Re-run option 7 to try again."
+        return 1
+    fi
+    echo "✓ Role assigned to AKS kubelet identity (may take 1-2 minutes to propagate)"
     echo ""
 
     # Update the deployment.yaml with the correct ACR endpoint and Foundry endpoint


### PR DESCRIPTION
Fixes #177 

Changes proposed in this pull request:

- Added role assignment failure handling to for Cognitive Services User assignment. If it fails, the script now says it failed and prompts the user to rerun the creation option.
-
-