### PR TITLE
Fix silent "Failed to create AKS cluster" on fresh subscriptions by registering required resource providers

### DIFF
--- a/instructions/azure-kubernetes-service/01-aks-deploy-container.md
+++ b/instructions/azure-kubernetes-service/01-aks-deploy-container.md
@@ -69,6 +69,7 @@ In this section you download the starter files for the console app and use a scr
 1. Run the following commands to ensure your subscription has the necessary resource providers to install AKS, ACR, and the Foundry AI model.
 
     ```
+    az provider register --namespace Microsoft.Network
     az provider register --namespace Microsoft.CognitiveServices
     az provider register --namespace Microsoft.ContainerService
     az provider register --namespace Microsoft.ContainerRegistry


### PR DESCRIPTION
# Module: [Deploy applications to Azure Kubernetes Service](https://learn.microsoft.com/en-gb/training/modules/deploy-apps-azure-kubernetes-service/5-exercise-deploy-ai-api)
## Lab/Demo: [Exercise - Deploy an AI inference API to Azure Kubernetes Service](https://microsoftlearning.github.io/mslearn-azure-ai/instructions/azure-kubernetes-service/01-aks-deploy-container.html)

Fixes # . Error: Failed to create AKS cluster.

Changes proposed in this pull request:

 ## Summary
  On a brand-new Azure subscription, the **"Create AKS cluster"** step of the lab
  (`azdeploy.sh` / `azdeploy.ps1`, menu option **5**) fails. Because both scripts send
  all CLI output to null (`> /dev/null 2>&1` in bash, `2>$null | Out-Null` in PowerShell),
  the user only sees the generic message:

      Error: Failed to create AKS cluster.

  ...with no indication of what actually went wrong. This makes the lab very hard to
  complete on a freshly created subscription.

  ## Root cause
  `az aks create` implicitly tries to register the `Microsoft.Network` resource provider.
  On a fresh subscription this provider is not registered yet, and the implicit
  registration can fail with a transient conflict. The cluster is then left in
  `provisioningState = Failed`.

  Confirmed from the activity log:

      RegisterProviderFailed: Register resource provider Microsoft.Network failed.
      The operation was interrupted by a conflicting concurrent write on the same
      entity. Please retry later.

  ## How to reproduce
  1. Use a newly created subscription where `Microsoft.Network` is not yet registered
     (`az provider show --namespace Microsoft.Network --query registrationState -o tsv`
     returns `NotRegistered` / `Registering`).
  2. Run the deployment script and choose option **5 (Create AKS cluster)**.
  3. The script prints `Error: Failed to create AKS cluster.` with no detail; the cluster
     ends up in `provisioningState = Failed`.

  ## Fix
  Explicitly register the required resource providers