### PR TITLE
Update GitHub pages link for Azure AI exercises

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Microsoft Lab Exercises
 <!-- Change the title above as appropriate -->
-[GitHub pages for the exercises](https://microsoftlearning.github.io/mslearn-azure-developer/)
+[GitHub pages for the exercises](https://microsoftlearning.github.io/mslearn-azure-ai/)
 
 This repo contains exercises and supporting files for Microsoft skilling content.
 


### PR DESCRIPTION
Readme incorrectly links to old AZ-204 lab content.