### PR TITLE
Move AKS Foundry purge option later in menu

### DIFF
--- a/finished/aks/deploy-aks/python/azdeploy.ps1
+++ b/finished/aks/deploy-aks/python/azdeploy.ps1
@@ -41,12 +41,12 @@ function Show-Menu {
     Write-Host "AKS Cluster: $aksCluster"
     Write-Host "====================================================================="
     Write-Host "1. Provision gpt-5-mini model in Microsoft Foundry"
-    Write-Host "2. Delete/Purge Foundry deployment"
-    Write-Host "3. Create Azure Container Registry (ACR)"
-    Write-Host "4. Build and push API image to ACR"
-    Write-Host "5. Create AKS cluster"
-    Write-Host "6. Check deployment status"
-    Write-Host "7. Deploy to AKS"
+    Write-Host "2. Create Azure Container Registry (ACR)"
+    Write-Host "3. Build and push API image to ACR"
+    Write-Host "4. Create AKS cluster"
+    Write-Host "5. Check deployment status"
+    Write-Host "6. Deploy to AKS"
+    Write-Host "7. Delete/Purge Foundry deployment"
     Write-Host "8. Exit"
     Write-Host "====================================================================="
 }
@@ -323,7 +323,7 @@ function Deploy-ToAKS {
         --scope $foundryResourceId 2>$null | Out-Null
 
     if ($LASTEXITCODE -ne 0) {
-        Write-Host "Error: Failed to assign Cognitive Services OpenAI User role. Re-run option 7 to try again."
+        Write-Host "Error: Failed to assign Cognitive Services OpenAI User role. Re-run option 6 to try again."
         return $false
     }
     Write-Host "$([char]0x2713) Role assigned to AKS kubelet identity (may take 1-2 minutes to propagate)"
@@ -508,39 +508,39 @@ while ($true) {
         }
         "2" {
             Write-Host ""
-            Delete-FoundryResource | Out-Null
-            Write-Host ""
-            Read-Host "Press Enter to continue"
-        }
-        "3" {
-            Write-Host ""
             Create-ResourceGroup | Out-Null
             Write-Host ""
             Create-ACR | Out-Null
             Write-Host ""
             Read-Host "Press Enter to continue"
         }
-        "4" {
+        "3" {
             Write-Host ""
             Build-AndPushImage | Out-Null
             Write-Host ""
             Read-Host "Press Enter to continue"
         }
-        "5" {
+        "4" {
             Write-Host ""
             Create-AKSCluster | Out-Null
             Write-Host ""
             Read-Host "Press Enter to continue"
         }
-        "6" {
+        "5" {
             Write-Host ""
             Check-DeploymentStatus | Out-Null
             Write-Host ""
             Read-Host "Press Enter to continue"
         }
-        "7" {
+        "6" {
             Write-Host ""
             Deploy-ToAKS | Out-Null
+            Write-Host ""
+            Read-Host "Press Enter to continue"
+        }
+        "7" {
+            Write-Host ""
+            Delete-FoundryResource | Out-Null
             Write-Host ""
             Read-Host "Press Enter to continue"
         }

--- a/finished/aks/deploy-aks/python/azdeploy.sh
+++ b/finished/aks/deploy-aks/python/azdeploy.sh
@@ -42,12 +42,12 @@ show_menu() {
     echo "AKS Cluster: $aks_cluster"
     echo "====================================================================="
     echo "1. Provision gpt-5-mini model in Microsoft Foundry"
-    echo "2. Delete/Purge Foundry deployment"
-    echo "3. Create Azure Container Registry (ACR)"
-    echo "4. Build and push API image to ACR"
-    echo "5. Create AKS cluster"
-    echo "6. Check deployment status"
-    echo "7. Deploy to AKS"
+    echo "2. Create Azure Container Registry (ACR)"
+    echo "3. Build and push API image to ACR"
+    echo "4. Create AKS cluster"
+    echo "5. Check deployment status"
+    echo "6. Deploy to AKS"
+    echo "7. Delete/Purge Foundry deployment"
     echo "8. Exit"
     echo "====================================================================="
 }
@@ -325,7 +325,7 @@ deploy_to_aks() {
         --scope "$foundry_resource_id" > /dev/null 2>&1
 
     if [ $? -ne 0 ]; then
-        echo "Error: Failed to assign Cognitive Services OpenAI User role. Re-run option 7 to try again."
+        echo "Error: Failed to assign Cognitive Services OpenAI User role. Re-run option 6 to try again."
         return 1
     fi
     echo "✓ Role assigned to AKS kubelet identity (may take 1-2 minutes to propagate)"
@@ -506,39 +506,39 @@ while true; do
             ;;
         2)
             echo ""
-            delete_foundry_resource
-            echo ""
-            read -p "Press Enter to continue..."
-            ;;
-        3)
-            echo ""
             create_resource_group
             echo ""
             create_acr
             echo ""
             read -p "Press Enter to continue..."
             ;;
-        4)
+        3)
             echo ""
             build_and_push_image
             echo ""
             read -p "Press Enter to continue..."
             ;;
-        5)
+        4)
             echo ""
             create_aks_cluster
             echo ""
             read -p "Press Enter to continue..."
             ;;
-        6)
+        5)
             echo ""
             check_deployment_status
             echo ""
             read -p "Press Enter to continue..."
             ;;
-        7)
+        6)
             echo ""
             deploy_to_aks
+            echo ""
+            read -p "Press Enter to continue..."
+            ;;
+        7)
+            echo ""
+            delete_foundry_resource
             echo ""
             read -p "Press Enter to continue..."
             ;;

--- a/instructions/azure-kubernetes-service/01-aks-deploy-container.md
+++ b/instructions/azure-kubernetes-service/01-aks-deploy-container.md
@@ -101,15 +101,15 @@ With the deployment script running, follow these steps to create the needed reso
 
 1. Enter **1** to launch the **1. Provision gpt-5-mini model in Microsoft Foundry** option. This option creates the resource group if it doesn't already exist, creates the resource in MIcrosoft Foundry, and deploys the **gpt-5-mini** model to the resource.
 
-    > **Important:** If there are errors during the model deployment, enter **2** to launch the **2. Delete/Purge Foundry deployment** option. This will delete the deployment and purge the resource name. Exit the menu, and change the region in the deployment script to one of the other recommended regions. Then restart the deployment script and run the model provisioning option again.
+  > **Important:** If there are errors during the model deployment, enter **7** to launch the **7. Delete/Purge Foundry deployment** option. This will delete the deployment and purge the resource name. Exit the menu, and change the region in the deployment script to one of the other recommended regions. Then restart the deployment script and run the model provisioning option again.
 
-1. After the model is deployed, enter **3** to launch **3. Create Azure Container Registry (ACR)**. This creates the resource where the API container will be stored, and later pulled into the AKS resource.
+1. After the model is deployed, enter **2** to launch **2. Create Azure Container Registry (ACR)**. This creates the resource where the API container will be stored, and later pulled into the AKS resource.
 
-1. After the ACR resource has been created, enter **4** to launch **Build and push API image to ACR**. This option uses ACR tasks to build the image and add it to the ACR repository. This operation can take 3-5 minutes to complete.
+1. After the ACR resource has been created, enter **3** to launch **3. Build and push API image to ACR**. This option uses ACR tasks to build the image and add it to the ACR repository. This operation can take 3-5 minutes to complete.
 
-1. After the image has been built and pushed to ACR, enter **5** to launch the **5. Create AKS cluster** option. This creates the AKS resource configured with a managed identity and gives the service permission to pull images from the ACR resource. This operation can take 5-10 minutes to complete.
+1. After the image has been built and pushed to ACR, enter **4** to launch the **4. Create AKS cluster** option. This creates the AKS resource configured with a managed identity and gives the service permission to pull images from the ACR resource. This operation can take 5-10 minutes to complete.
 
-1. After the AKS resources has been deployed, enter **6** to launch the **6. Check deployment status** option. This option reports if each of the three resources have been successfully deployed.
+1. After the AKS resources has been deployed, enter **5** to launch the **5. Check deployment status** option. This option reports if each of the three resources have been successfully deployed.
 
     If all of the services return a **successful** message, enter **8** to exit the deployment script.
 
@@ -221,7 +221,7 @@ In this section you use the deployment script to apply the manifests to AKS.
     Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
     ```
 
-1. Enter **7** to launch the **7. Deploy to AKS** option. This option performs several operations: it retrieves your AKS credentials and configures kubectl, assigns the **Cognitive Services OpenAI User** role to the AKS kubelet managed identity so the API can authenticate to Foundry using Microsoft Entra ID, updates the deployment manifest with your ACR endpoint and Foundry endpoint, and then uses **kubectl apply** to deploy both manifests to your AKS cluster. When the operation is complete, enter **8** to exit the deployment script.
+1. Enter **6** to launch the **6. Deploy to AKS** option. This option performs several operations: it retrieves your AKS credentials and configures kubectl, assigns the **Cognitive Services OpenAI User** role to the AKS kubelet managed identity so the API can authenticate to Foundry using Microsoft Entra ID, updates the deployment manifest with your ACR endpoint and Foundry endpoint, and then uses **kubectl apply** to deploy both manifests to your AKS cluster. When the operation is complete, enter **8** to exit the deployment script.
 
 1. Run the following commands in the terminal to verify the deployment. Expect **kubectl get deploy,svc** to show the Deployment **READY** as **1/1** (or your replica count) and the Service **EXTERNAL-IP** to have a public IP (not **\<pending>**). The rollout command should print **deployment "aks-api" successfully rolled out** when the update is complete.
 

--- a/starter/aks/deploy-aks/python/azdeploy.ps1
+++ b/starter/aks/deploy-aks/python/azdeploy.ps1
@@ -38,12 +38,12 @@ function Show-Menu {
     Write-Host "AKS Cluster: $aksCluster"
     Write-Host "====================================================================="
     Write-Host "1. Provision gpt-5-mini model in Microsoft Foundry"
-    Write-Host "2. Delete/Purge Foundry deployment"
-    Write-Host "3. Create Azure Container Registry (ACR)"
-    Write-Host "4. Build and push API image to ACR"
-    Write-Host "5. Create AKS cluster"
-    Write-Host "6. Check deployment status"
-    Write-Host "7. Deploy to AKS"
+    Write-Host "2. Create Azure Container Registry (ACR)"
+    Write-Host "3. Build and push API image to ACR"
+    Write-Host "4. Create AKS cluster"
+    Write-Host "5. Check deployment status"
+    Write-Host "6. Deploy to AKS"
+    Write-Host "7. Delete/Purge Foundry deployment"
     Write-Host "8. Exit"
     Write-Host "====================================================================="
 }
@@ -320,7 +320,7 @@ function Deploy-ToAKS {
         --scope $foundryResourceId 2>$null | Out-Null
 
     if ($LASTEXITCODE -ne 0) {
-        Write-Host "Error: Failed to assign Cognitive Services OpenAI User role. Re-run option 7 to try again."
+        Write-Host "Error: Failed to assign Cognitive Services OpenAI User role. Re-run option 6 to try again."
         return $false
     }
     Write-Host "$([char]0x2713) Role assigned to AKS kubelet identity (may take 1-2 minutes to propagate)"
@@ -505,39 +505,39 @@ while ($true) {
         }
         "2" {
             Write-Host ""
-            Delete-FoundryResource | Out-Null
-            Write-Host ""
-            Read-Host "Press Enter to continue"
-        }
-        "3" {
-            Write-Host ""
             Create-ResourceGroup | Out-Null
             Write-Host ""
             Create-ACR | Out-Null
             Write-Host ""
             Read-Host "Press Enter to continue"
         }
-        "4" {
+        "3" {
             Write-Host ""
             Build-AndPushImage | Out-Null
             Write-Host ""
             Read-Host "Press Enter to continue"
         }
-        "5" {
+        "4" {
             Write-Host ""
             Create-AKSCluster | Out-Null
             Write-Host ""
             Read-Host "Press Enter to continue"
         }
-        "6" {
+        "5" {
             Write-Host ""
             Check-DeploymentStatus | Out-Null
             Write-Host ""
             Read-Host "Press Enter to continue"
         }
-        "7" {
+        "6" {
             Write-Host ""
             Deploy-ToAKS | Out-Null
+            Write-Host ""
+            Read-Host "Press Enter to continue"
+        }
+        "7" {
+            Write-Host ""
+            Delete-FoundryResource | Out-Null
             Write-Host ""
             Read-Host "Press Enter to continue"
         }

--- a/starter/aks/deploy-aks/python/azdeploy.sh
+++ b/starter/aks/deploy-aks/python/azdeploy.sh
@@ -39,12 +39,12 @@ show_menu() {
     echo "AKS Cluster: $aks_cluster"
     echo "====================================================================="
     echo "1. Provision gpt-5-mini model in Microsoft Foundry"
-    echo "2. Delete/Purge Foundry deployment"
-    echo "3. Create Azure Container Registry (ACR)"
-    echo "4. Build and push API image to ACR"
-    echo "5. Create AKS cluster"
-    echo "6. Check deployment status"
-    echo "7. Deploy to AKS"
+    echo "2. Create Azure Container Registry (ACR)"
+    echo "3. Build and push API image to ACR"
+    echo "4. Create AKS cluster"
+    echo "5. Check deployment status"
+    echo "6. Deploy to AKS"
+    echo "7. Delete/Purge Foundry deployment"
     echo "8. Exit"
     echo "====================================================================="
 }
@@ -322,7 +322,7 @@ deploy_to_aks() {
         --scope "$foundry_resource_id" > /dev/null 2>&1
 
     if [ $? -ne 0 ]; then
-        echo "Error: Failed to assign Cognitive Services OpenAI User role. Re-run option 7 to try again."
+        echo "Error: Failed to assign Cognitive Services OpenAI User role. Re-run option 6 to try again."
         return 1
     fi
     echo "✓ Role assigned to AKS kubelet identity (may take 1-2 minutes to propagate)"
@@ -503,39 +503,39 @@ while true; do
             ;;
         2)
             echo ""
-            delete_foundry_resource
-            echo ""
-            read -p "Press Enter to continue..."
-            ;;
-        3)
-            echo ""
             create_resource_group
             echo ""
             create_acr
             echo ""
             read -p "Press Enter to continue..."
             ;;
-        4)
+        3)
             echo ""
             build_and_push_image
             echo ""
             read -p "Press Enter to continue..."
             ;;
-        5)
+        4)
             echo ""
             create_aks_cluster
             echo ""
             read -p "Press Enter to continue..."
             ;;
-        6)
+        5)
             echo ""
             check_deployment_status
             echo ""
             read -p "Press Enter to continue..."
             ;;
-        7)
+        6)
             echo ""
             deploy_to_aks
+            echo ""
+            read -p "Press Enter to continue..."
+            ;;
+        7)
+            echo ""
+            delete_foundry_resource
             echo ""
             read -p "Press Enter to continue..."
             ;;


### PR DESCRIPTION
# Module: 03 Kubernetes
## Lab/Demo: 06

Fixes #215.

Changes proposed in this pull request:

- Moves the Delete/Purge Foundry deployment menu option later in the AKS deploy script flow.
- Renumbers the normal deployment path so learners can proceed sequentially from provisioning through deployment.
- Updates starter scripts, finished scripts, and lab instructions so option references remain aligned.
---
Module: 03 Kubernetes
Lab: 06
Issue: #215