### PR TITLE
Fix AMR pub-sub subscriber dialog fonts

### DIFF
--- a/finished/amr/pub-sub/python/subscriber_gui.py
+++ b/finished/amr/pub-sub/python/subscriber_gui.py
@@ -108,7 +108,7 @@ class SubscriberGUI:
         dialog.title("Subscribe to Channel")
         dialog.geometry("400x250")
         
-        tk.Label(dialog, text="Available channels:", font=(self.default_font, "bold")).pack(pady=10)
+        tk.Label(dialog, text="Available channels:", font=self.default_bold).pack(pady=10)
         channels_text = "  - orders:created\n  - orders:shipped\n  - inventory:alerts\n  - notifications"
         tk.Label(dialog, text=channels_text, justify=tk.LEFT).pack()
         
@@ -135,7 +135,7 @@ class SubscriberGUI:
         dialog.title("Subscribe with Pattern")
         dialog.geometry("400x250")
         
-        tk.Label(dialog, text="Pattern examples:", font=(self.default_font, "bold")).pack(pady=10)
+        tk.Label(dialog, text="Pattern examples:", font=self.default_bold).pack(pady=10)
         patterns_text = "  - orders:*       (matches orders:created, orders:shipped, etc.)\n  - inventory:*    (matches all inventory channels)\n  - *              (matches all channels)"
         tk.Label(dialog, text=patterns_text, justify=tk.LEFT).pack()
         

--- a/starter/amr/pub-sub/python/subscriber_gui.py
+++ b/starter/amr/pub-sub/python/subscriber_gui.py
@@ -108,7 +108,7 @@ class SubscriberGUI:
         dialog.title("Subscribe to Channel")
         dialog.geometry("400x250")
         
-        tk.Label(dialog, text="Available channels:", font=(self.default_font, "bold")).pack(pady=10)
+        tk.Label(dialog, text="Available channels:", font=self.default_bold).pack(pady=10)
         channels_text = "  - orders:created\n  - orders:shipped\n  - inventory:alerts\n  - notifications"
         tk.Label(dialog, text=channels_text, justify=tk.LEFT).pack()
         
@@ -135,7 +135,7 @@ class SubscriberGUI:
         dialog.title("Subscribe with Pattern")
         dialog.geometry("400x250")
         
-        tk.Label(dialog, text="Pattern examples:", font=(self.default_font, "bold")).pack(pady=10)
+        tk.Label(dialog, text="Pattern examples:", font=self.default_bold).pack(pady=10)
         patterns_text = "  - orders:*       (matches orders:created, orders:shipped, etc.)\n  - inventory:*    (matches all inventory channels)\n  - *              (matches all channels)"
         tk.Label(dialog, text=patterns_text, justify=tk.LEFT).pack()
         


### PR DESCRIPTION
# Module: Azure Managed Redis
## Lab/Demo: Pub/sub

Fixes #217.

Changes proposed in this pull request:

- Replaces invalid Tkinter tuple font definitions in the AMR pub/sub subscriber dialogs with the existing `self.default_bold` font object.
- Applies the fix to both starter and finished copies of `subscriber_gui.py`.
- Validates both updated Python files with `python -m py_compile`.