### PR TITLE
M02 - LAB02 - Add warning for Log Analytics extension installation during command execution

### DIFF
--- a/instructions/azure-container-apps/02-aca-manage-containers.md
+++ b/instructions/azure-container-apps/02-aca-manage-containers.md
@@ -360,6 +360,8 @@ Console logs shown by **az containerapp logs show** are recent only. For histori
         --analytics-query "ContainerAppConsoleLogs_CL | where ContainerAppName_s == '$env:CONTAINER_APP_NAME' | project TimeGenerated, Log_s | order by TimeGenerated desc | take 20" `
         -o table
     ```
+    > [!WARNING]
+    > If you get an error like _"Preview version of extension is disabled by default for extension installation, enabled for modules without stable versions. Please run 'az config set extension. or false' to config it specifically. The command requires the extension log—analytics. Do you want to install it now? The command will continue to run after the extension is installed. (Y/n):"_ when running the command, select Y to continue installing the extension.
 
     > [!NOTE]
     > Log Analytics data may take a few minutes to appear after events occur. If you don't see recent logs, wait a few minutes and try again.

--- a/instructions/azure-container-apps/02-aca-manage-containers.md
+++ b/instructions/azure-container-apps/02-aca-manage-containers.md
@@ -68,6 +68,7 @@ In this section you download the project starter files and use a script to deplo
 
     ```azurecli
     az extension add --name containerapp
+    az extension add --name log-analytics
     ```
 
 1. Run the following commands to ensure your subscription has the necessary resource providers for the exercise.
@@ -360,9 +361,6 @@ Console logs shown by **az containerapp logs show** are recent only. For histori
         --analytics-query "ContainerAppConsoleLogs_CL | where ContainerAppName_s == '$env:CONTAINER_APP_NAME' | project TimeGenerated, Log_s | order by TimeGenerated desc | take 20" `
         -o table
     ```
-    > [!WARNING]
-    > If you get an error like _"Preview version of extension is disabled by default for extension installation, enabled for modules without stable versions. Please run 'az config set extension. or false' to config it specifically. The command requires the extension log—analytics. Do you want to install it now? The command will continue to run after the extension is installed. (Y/n):"_ when running the command, select Y to continue installing the extension.
-
     > [!NOTE]
     > Log Analytics data may take a few minutes to appear after events occur. If you don't see recent logs, wait a few minutes and try again.
 


### PR DESCRIPTION
# Module: 02
## Lab/Demo: 02

Changes proposed in this pull request:

This pull request adds a helpful warning to the Azure Container Apps management documentation to address a common error encountered when running log analytics commands.

Documentation improvements:

* Added a warning to `instructions/azure-container-apps/02-aca-manage-containers.md` explaining that if users see an extension installation prompt when running log analytics commands, they should select 'Y' to proceed.